### PR TITLE
Simplify AI processing by using server-side API key

### DIFF
--- a/gas-comparator/api/extract-contracts.ts
+++ b/gas-comparator/api/extract-contracts.ts
@@ -16,6 +16,8 @@ interface ExtractedOffer {
   consommationReference?: number;
 }
 
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // CORS Headers
   res.setHeader('Access-Control-Allow-Origin', '*');
@@ -37,9 +39,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       return res.status(400).json({ error: 'Texte manquant' });
     }
 
-    const apiKey = process.env.OPENAI_API_KEY;
-    if (!apiKey) {
-      return res.status(500).json({ error: 'Clé API OpenAI non configurée sur Vercel' });
+    if (!OPENAI_API_KEY) {
+      return res.status(500).json({ error: 'Clé API OpenAI non configurée sur le serveur' });
     }
 
     console.log(`🔄 Traitement: ${fileName}`);
@@ -55,7 +56,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Authorization': `Bearer ${apiKey}`
+        'Authorization': `Bearer ${OPENAI_API_KEY}`
       },
       body: JSON.stringify({
         model: 'gpt-4o-mini',

--- a/gas-comparator/src/components/ai/AIUploadSection.tsx
+++ b/gas-comparator/src/components/ai/AIUploadSection.tsx
@@ -10,7 +10,6 @@ interface Props {
 
 export default function AIUploadSection({ onDataExtracted, onBack }: Props) {
   const [files, setFiles] = useState<File[]>([]);
-  const [apiKey, setApiKey] = useState('');
   const { processFiles, isProcessing, progress, currentStep, error } = useAIProcessing();
 
   const handleFiles = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -20,7 +19,7 @@ export default function AIUploadSection({ onDataExtracted, onBack }: Props) {
   };
 
   const handleAnalyze = async () => {
-    const offers = await processFiles(files, apiKey || undefined);
+    const offers = await processFiles(files);
     const rows: ProviderRow[] = offers.map(o => ({
       id: o.id || crypto.randomUUID(),
       name: o.fournisseur,
@@ -43,13 +42,6 @@ export default function AIUploadSection({ onDataExtracted, onBack }: Props) {
         <ArrowLeft size={16} /> Retour
       </button>
       <input type="file" multiple onChange={handleFiles} className="block" />
-      <input
-        type="text"
-        placeholder="OpenAI API Key (optionnel)"
-        value={apiKey}
-        onChange={e => setApiKey(e.target.value)}
-        className="border p-2 rounded w-full"
-      />
       <button
         onClick={handleAnalyze}
         disabled={files.length === 0 || isProcessing}

--- a/gas-comparator/src/hooks/useAIProcessing.ts
+++ b/gas-comparator/src/hooks/useAIProcessing.ts
@@ -1,21 +1,14 @@
 import { useState } from 'react';
 import { useVercelAI } from '../services/vercelAIService';
-import { useRealAI } from '../services/realAIService';
 import { supabase } from '../lib/supabaseClient';
 import type { ExtractedOffer } from '../types/ai';
 
 export function useAIProcessing() {
   const vercel = useVercelAI();
-  const real = useRealAI();
   const [offers, setOffers] = useState<ExtractedOffer[]>([]);
 
-  const processFiles = async (files: File[], apiKey?: string) => {
-    let result: ExtractedOffer[] = [];
-    if (apiKey) {
-      result = await real.processFiles(files, apiKey);
-    } else {
-      result = await vercel.processFiles(files);
-    }
+  const processFiles = async (files: File[]) => {
+    const result = await vercel.processFiles(files);
     setOffers(result);
     try {
       if (result.length) {
@@ -36,9 +29,9 @@ export function useAIProcessing() {
     offers,
     processFiles,
     reset,
-    isProcessing: vercel.isProcessing || real.isProcessing,
-    progress: real.isProcessing ? real.progress : vercel.progress,
-    currentStep: real.isProcessing ? real.currentStep : vercel.currentStep,
-    error: real.error || vercel.error
+    isProcessing: vercel.isProcessing,
+    progress: vercel.progress,
+    currentStep: vercel.currentStep,
+    error: vercel.error
   };
 }


### PR DESCRIPTION
## Summary
- remove API key field and state from AIUploadSection
- rely solely on vercelAIService in useAIProcessing
- read `OPENAI_API_KEY` server-side in the extract-contracts endpoint and return clear errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm install` *(fails: 403 Forbidden for @supabase/supabase-js)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6bb79d8832c806e714a685f8fff