### PR TITLE
chore: use official Supabase types

### DIFF
--- a/gas-comparator/src/types/supabase-js.d.ts
+++ b/gas-comparator/src/types/supabase-js.d.ts
@@ -1,3 +1,0 @@
-declare module '@supabase/supabase-js' {
-  export function createClient(url: string, key: string): any;
-}


### PR DESCRIPTION
## Summary
- remove local Supabase client type override
- rely on official `@supabase/supabase-js` types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: unsupported TypeScript compiler options)*
- `npm install` *(fails: 403 fetching @supabase/supabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6b86948832c928ed0139f030515