### PR TITLE
docs: configure Supabase environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
 # copronomiev1
+
+## Configuration des variables d'environnement
+
+L'application utilise Supabase. Vous devez fournir l'URL du projet et la clé publique "anon".
+
+### Obtenir les clés Supabase
+
+1. Créez un projet sur [Supabase](https://supabase.com/).
+2. Dans le tableau de bord Supabase, ouvrez **Project Settings → API**.
+3. Relevez votre **Project URL** et votre **anon public key**.
+
+### Configuration locale
+
+Copiez le fichier `.env.example` en `.env` puis renseignez les valeurs :
+
+```bash
+VITE_SUPABASE_URL=...              # Project URL
+VITE_SUPABASE_ANON_KEY=...         # anon public key
+```
+
+### Configuration sur Vercel
+
+Dans les paramètres de votre projet Vercel, ajoutez les variables `VITE_SUPABASE_URL` et `VITE_SUPABASE_ANON_KEY`.
+Les appels à OpenAI sont effectués côté serveur ; définissez uniquement `OPENAI_API_KEY` dans l'environnement Vercel.
+

--- a/gas-comparator/.env.example
+++ b/gas-comparator/.env.example
@@ -1,2 +1,3 @@
-# OpenAI API Key (optionnel)
-VITE_OPENAI_API_KEY=sk-your-openai-key-here
+# Supabase credentials
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-anon-key

--- a/gas-comparator/README.md
+++ b/gas-comparator/README.md
@@ -1,69 +1,22 @@
-# React + TypeScript + Vite
+# Gas Comparator
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+## Variables d'environnement
 
-Currently, two official plugins are available:
+Copiez le fichier `.env.example` en `.env` et renseignez :
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+VITE_SUPABASE_URL=...      # Project URL depuis Supabase
+VITE_SUPABASE_ANON_KEY=... # anon public key
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+### Récupération des clés
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+1. Connectez-vous au [tableau de bord Supabase](https://app.supabase.com/).
+2. Ouvrez **Project Settings → API**.
+3. Copiez votre **Project URL** et la **anon public key**.
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+### Configuration sur Vercel
+
+Ajoutez `VITE_SUPABASE_URL` et `VITE_SUPABASE_ANON_KEY` dans **Vercel → Settings → Environment Variables**.
+L'API OpenAI est appelée côté serveur ; définissez uniquement `OPENAI_API_KEY` dans l'environnement Vercel.
+


### PR DESCRIPTION
## Summary
- add VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to sample env file
- document how to retrieve Supabase keys and set them locally and on Vercel
- remove client OpenAI key example

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm --prefix gas-comparator test` *(fails: Missing script: "test")*
- `npm --prefix gas-comparator run lint` *(fails: eslint: not found)*
- `npm --prefix gas-comparator install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@supabase%2fsupabase-js)*

------
https://chatgpt.com/codex/tasks/task_e_68b1b6b6dfb4832c99f98fd1432f77e1