### PR TITLE
docs: enrich project documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,39 @@
-# copronomiev1
+# Copronomie
+
+Copronomie est un comparateur de consommation et de prix du gaz destiné aux copropriétés. Le dépôt regroupe l'interface web et les fonctions API nécessaires à l'analyse des factures.
+
+## Architecture
+
+```
+[Frontend React/Vite] -> [API serverless Vercel] -> [Services externes]
+```
+
+- **gas-comparator/** : application front.
+- **gas-comparator/api/** : fonctions serverless Node exécutées par Vercel.
+
+## Commandes de développement
+
+Toutes les commandes suivantes se lancent depuis le dossier `gas-comparator/` :
+
+```bash
+npm install        # installe les dépendances
+npm run dev        # lance l'application en mode développement
+npm run lint       # vérifie le code
+npm run build      # génère la version de production
+```
+
+## Déploiement
+
+L'application est conçue pour être déployée sur [Vercel](https://vercel.com). Un push sur la branche principale déclenche un déploiement automatique. Pour déployer manuellement :
+
+```bash
+vercel --prod
+```
+
+## Roadmap
+
+- Intégrer l'authentification des utilisateurs
+- Couvrir l'API par des tests
+- Import automatique de nouvelles factures
+- Amélioration des graphiques comparatifs
+

--- a/gas-comparator/README.md
+++ b/gas-comparator/README.md
@@ -1,69 +1,27 @@
-# React + TypeScript + Vite
+# Gas Comparator
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+Application front développée avec React, TypeScript et Vite. Elle permet aux copropriétés de comparer les coûts de gaz et d'analyser les factures.
 
-Currently, two official plugins are available:
+## Installation
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      ...tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      ...tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      ...tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+npm install
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+## Développement
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+```bash
+npm run dev
+```
+Le serveur démarre sur [http://localhost:5173](http://localhost:5173).
 
-export default tseslint.config([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+## Lien avec l'API
+
+Les appels aux fonctionnalités d'analyse sont effectués via les fonctions serverless situées dans le dossier `api/`. Lors du développement, elles sont accessibles via des requêtes vers `/api/*` et sont déployées sur Vercel avec le front.
+
+## Lint et build
+
+```bash
+npm run lint   # vérifie le style du code
+npm run build  # génère la version de production
 ```


### PR DESCRIPTION
## Summary
- rewrite root README with product description, architecture, commands, deployment instructions and roadmap
- document gas-comparator frontend and its API link

## Testing
- `npm test` (fails: Missing script "test")
- `cd gas-comparator && npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68b1b6aee93c832c98e5fe7ae6705e07